### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # CMDataStorage
 
 [![Build Status](https://secure.travis-ci.org/mureev/CMDataStorage.png?branch=master)](http://travis-ci.org/mureev/CMDataStorage)
-[![Cocoapods](https://cocoapod-badges.herokuapp.com/v/CMDataStorage/badge.png)](http://cocoapods.org/?q=name%3ACMDataStorage%2A)
-[![Cocoapods](https://cocoapod-badges.herokuapp.com/p/CMDataStorage/badge.png)](http://cocoapods.org/?q=name%3ACMDataStorage%2A)
+[![CocoaPods](https://cocoapod-badges.herokuapp.com/v/CMDataStorage/badge.png)](http://cocoapods.org/?q=name%3ACMDataStorage%2A)
+[![CocoaPods](https://cocoapod-badges.herokuapp.com/p/CMDataStorage/badge.png)](http://cocoapods.org/?q=name%3ACMDataStorage%2A)
 ![License MIT](https://go-shields.herokuapp.com/license-MIT-blue.png)
 
 Simple and powerful API to work with NSData in IOS Cache, Documents and Temp folder.


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
